### PR TITLE
Delay *after* casting, not before

### DIFF
--- a/UltimateFishBot/Classes/BodyParts/Hands.cs
+++ b/UltimateFishBot/Classes/BodyParts/Hands.cs
@@ -34,8 +34,8 @@ namespace UltimateFishBot.Classes.BodyParts
         public void Cast()
         {
             Win32.ActivateWow();
-            System.Threading.Thread.Sleep(Properties.Settings.Default.CastingDelay);
             Win32.SendKey(Properties.Settings.Default.FishKey);
+            System.Threading.Thread.Sleep(Properties.Settings.Default.CastingDelay);
         }
 
         public void Loot()


### PR DESCRIPTION
"Delay After Cast" is described as "The number of milliseconds to wait
after the cast before searching."
However, fishbot sleeps first, then sends the key press, waiting
**before the cast**. This is incorrect.

Moving the sleep to be before the cast fixes the problem.