### PR TITLE
Rewrite for persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ node_modules/
 Generated_Code/
 
 # Backup & report files from converting an old project file
+
+# VS 2017 express files
+.vs/
 # to a newer Visual Studio version. Backup files are not needed,
 # because we have git ;-)
 _UpgradeReport_Files/

--- a/UltimateFishBot/Classes/BodyParts/Eyes.cs
+++ b/UltimateFishBot/Classes/BodyParts/Eyes.cs
@@ -16,11 +16,17 @@ namespace UltimateFishBot.Classes.BodyParts
         int yPosMax;
         Rectangle wowRectangle;
         private Win32.CursorInfo m_noFishCursor;
+        private IntPtr Wow;
+
+        public Eyes(IntPtr wowWindow)
+        {
+            this.Wow = wowWindow;
+        }
 
         public async Task<bool> LookForBobber(CancellationToken cancellationToken)
         {
             m_noFishCursor = Win32.GetNoFishCursor();
-            wowRectangle = Win32.GetWowRectangle();
+            wowRectangle = Win32.GetWowRectangle(this.Wow);
 
             if (!Properties.Settings.Default.customScanArea)
             {

--- a/UltimateFishBot/Classes/BodyParts/Eyes.cs
+++ b/UltimateFishBot/Classes/BodyParts/Eyes.cs
@@ -25,7 +25,7 @@ namespace UltimateFishBot.Classes.BodyParts
 
         public async Task<bool> LookForBobber(CancellationToken cancellationToken)
         {
-            m_noFishCursor = Win32.GetNoFishCursor();
+            m_noFishCursor = Win32.GetNoFishCursor(this.Wow);
             wowRectangle = Win32.GetWowRectangle(this.Wow);
 
             if (!Properties.Settings.Default.customScanArea)

--- a/UltimateFishBot/Classes/BodyParts/Hands.cs
+++ b/UltimateFishBot/Classes/BodyParts/Hands.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using UltimateFishBot.Classes.Helpers;
@@ -10,11 +11,19 @@ namespace UltimateFishBot.Classes.BodyParts
         private Cursor m_cursor;
         private int m_baitIndex;
         private string[] m_baitKeys;
+        private IntPtr Wow;
 
         public Hands()
         {
             m_baitIndex = 0;
             m_cursor    = new Cursor(Cursor.Current.Handle);
+            UpdateKeys();
+        }
+        public Hands(IntPtr wowWindow)
+        {
+            this.Wow = wowWindow;
+            m_baitIndex = 0;
+            m_cursor = new Cursor(Cursor.Current.Handle);
             UpdateKeys();
         }
 
@@ -34,7 +43,7 @@ namespace UltimateFishBot.Classes.BodyParts
 
         public async Task Cast(CancellationToken token)
         {
-            Win32.ActivateWow();
+            Win32.ActivateWow(this.Wow);
             Win32.SendKey(Properties.Settings.Default.FishKey);
             await Task.Delay(Properties.Settings.Default.CastingDelay, token);
         }
@@ -106,7 +115,7 @@ namespace UltimateFishBot.Classes.BodyParts
                     return;
             }
 
-            Win32.ActivateWow();
+            Win32.ActivateWow(this.Wow);
             Win32.SendKey(actionKey);
             await Task.Delay(sleepTime * 1000, cancellationToken);
         }

--- a/UltimateFishBot/Classes/Helpers/Win32.cs
+++ b/UltimateFishBot/Classes/Helpers/Win32.cs
@@ -91,7 +91,7 @@ namespace UltimateFishBot.Classes.Helpers
         private const uint WM_RBUTTONDOWN = 516;
         private const uint WM_RBUTTONUP = 517;
 
-
+        /*
         public static Rectangle GetWowRectangle()
         {
             IntPtr Wow = FindWowWindow();
@@ -105,7 +105,7 @@ namespace UltimateFishBot.Classes.Helpers
             myRect.Width = (Win32ApiRect.Right - Win32ApiRect.Left);
             myRect.Height = (Win32ApiRect.Bottom - Win32ApiRect.Top);
             return myRect;
-        }
+        }*/
         public static Rectangle GetWowRectangle(IntPtr Wow)
         {
             Rect Win32ApiRect = new Rect();
@@ -148,17 +148,19 @@ namespace UltimateFishBot.Classes.Helpers
             return actualCursorIcon;
         }
 
+        /*
         static public void ActivateWow()
         {
             ActivateApp(Properties.Settings.Default.ProcName);
             ActivateApp(Properties.Settings.Default.ProcName + "-64");
             ActivateApp("World Of Warcraft");
         }
+        */
         static public void ActivateWow(IntPtr Wow)
         {
             ActivateApp(Wow);
         }
-
+        /*
         static public void ActivateApp(string processName)
         {
             Process[] p = Process.GetProcessesByName(processName);
@@ -166,7 +168,7 @@ namespace UltimateFishBot.Classes.Helpers
             // Activate the first application we find with this name
             if (p.Count() > 0)
                 SetForegroundWindow(p[0].MainWindowHandle);
-        }
+        }*/
         static public void ActivateApp(IntPtr Wow)
         {
             SetForegroundWindow(Wow);
@@ -186,9 +188,9 @@ namespace UltimateFishBot.Classes.Helpers
             }
         }
 
-        public static CursorInfo GetNoFishCursor()
+        public static CursorInfo GetNoFishCursor(IntPtr Wow)
         {
-            Rectangle WoWRect = Win32.GetWowRectangle();
+            Rectangle WoWRect = Win32.GetWowRectangle(Wow);
             Win32.MoveMouse((WoWRect.X + 10), (WoWRect.Y + 45));
             LastRectX = WoWRect.X;
             LastRectY = WoWRect.Y;

--- a/UltimateFishBot/Classes/Helpers/Win32.cs
+++ b/UltimateFishBot/Classes/Helpers/Win32.cs
@@ -97,7 +97,7 @@ namespace UltimateFishBot.Classes.Helpers
             Process[] processlist = Process.GetProcesses();
             foreach(Process process in processlist)
             {
-                if(process.MainWindowTitle.Equals("World of Warcraft"))
+                if(process.MainWindowTitle.ToUpper().Equals("WORLD OF WARCRAFT"))
                 {
                     return process.MainWindowHandle;
                 }

--- a/UltimateFishBot/Classes/Helpers/Win32.cs
+++ b/UltimateFishBot/Classes/Helpers/Win32.cs
@@ -91,21 +91,6 @@ namespace UltimateFishBot.Classes.Helpers
         private const uint WM_RBUTTONDOWN = 516;
         private const uint WM_RBUTTONUP = 517;
 
-        /*
-        public static Rectangle GetWowRectangle()
-        {
-            IntPtr Wow = FindWowWindow();
-            Rect Win32ApiRect = new Rect();
-            GetWindowRect(Wow, ref Win32ApiRect);
-            System.Console.WriteLine("right rectangle:");
-            System.Console.WriteLine(Win32ApiRect.Right);
-            Rectangle myRect = new Rectangle();
-            myRect.X = Win32ApiRect.Left;
-            myRect.Y = Win32ApiRect.Top;
-            myRect.Width = (Win32ApiRect.Right - Win32ApiRect.Left);
-            myRect.Height = (Win32ApiRect.Bottom - Win32ApiRect.Top);
-            return myRect;
-        }*/
         public static Rectangle GetWowRectangle(IntPtr Wow)
         {
             Rect Win32ApiRect = new Rect();
@@ -119,6 +104,7 @@ namespace UltimateFishBot.Classes.Helpers
             myRect.Height = (Win32ApiRect.Bottom - Win32ApiRect.Top);
             return myRect;
         }
+
         public static IntPtr FindWowWindow()
         {
             Process[] processlist = Process.GetProcesses();
@@ -148,28 +134,12 @@ namespace UltimateFishBot.Classes.Helpers
             return actualCursorIcon;
         }
 
-        /*
-        static public void ActivateWow()
-        {
-            ActivateApp(Properties.Settings.Default.ProcName);
-            ActivateApp(Properties.Settings.Default.ProcName + "-64");
-            ActivateApp("World Of Warcraft");
-        }
-        */
         static public void ActivateWow(IntPtr Wow)
         {
             ActivateApp(Wow);
         }
-        /*
-        static public void ActivateApp(string processName)
-        {
-            Process[] p = Process.GetProcessesByName(processName);
 
-            // Activate the first application we find with this name
-            if (p.Count() > 0)
-                SetForegroundWindow(p[0].MainWindowHandle);
-        }*/
-        static public void ActivateApp(IntPtr Wow)
+        public static void ActivateApp(IntPtr Wow)
         {
             SetForegroundWindow(Wow);
             //AllowSetForegroundWindow(Process.GetCurrentProcess().Id);
@@ -237,6 +207,7 @@ namespace UltimateFishBot.Classes.Helpers
             if (Properties.Settings.Default.ShiftLoot)
                 SendKeyboardAction(16, keyState.KEYUP);
         }
+
         public static void SendMouseClick(IntPtr Wow)
         {
             long dWord = MakeDWord((LastX - LastRectX), (LastY - LastRectY));
@@ -267,10 +238,10 @@ namespace UltimateFishBot.Classes.Helpers
             return (HiWord << 16) | (LoWord & 0xFFFF);
         }
 
-        static private int LastRectX;
-        static private int LastRectY;
+        private static int LastRectX;
+        private static int LastRectY;
 
-        static private int LastX;
-        static private int LastY;
+        private static int LastX;
+        private static int LastY;
     }
 }

--- a/UltimateFishBot/Classes/Helpers/Win32.cs
+++ b/UltimateFishBot/Classes/Helpers/Win32.cs
@@ -92,6 +92,19 @@ namespace UltimateFishBot.Classes.Helpers
             myRect.Height = (Win32ApiRect.Bottom - Win32ApiRect.Top);
             return myRect;
         }
+        public static Rectangle GetWowRectangle(IntPtr Wow)
+        {
+            Rect Win32ApiRect = new Rect();
+            GetWindowRect(Wow, ref Win32ApiRect);
+            System.Console.WriteLine("right rectangle:");
+            System.Console.WriteLine(Win32ApiRect.Right);
+            Rectangle myRect = new Rectangle();
+            myRect.X = Win32ApiRect.Left;
+            myRect.Y = Win32ApiRect.Top;
+            myRect.Width = (Win32ApiRect.Right - Win32ApiRect.Left);
+            myRect.Height = (Win32ApiRect.Bottom - Win32ApiRect.Top);
+            return myRect;
+        }
         public static IntPtr FindWowWindow()
         {
             Process[] processlist = Process.GetProcesses();
@@ -127,6 +140,10 @@ namespace UltimateFishBot.Classes.Helpers
             ActivateApp(Properties.Settings.Default.ProcName + "-64");
             ActivateApp("World Of Warcraft");
         }
+        static public void ActivateWow(IntPtr Wow)
+        {
+            ActivateApp(Wow);
+        }
 
         static public void ActivateApp(string processName)
         {
@@ -135,6 +152,10 @@ namespace UltimateFishBot.Classes.Helpers
             // Activate the first application we find with this name
             if (p.Count() > 0)
                 SetForegroundWindow(p[0].MainWindowHandle);
+        }
+        static public void ActivateApp(IntPtr Wow)
+        {
+            SetForegroundWindow(Wow);
         }
 
         public static void MoveMouse(int x, int y)
@@ -183,6 +204,20 @@ namespace UltimateFishBot.Classes.Helpers
         public static void SendMouseClick()
         {
             IntPtr Wow = FindWowWindow();
+            long dWord = MakeDWord((LastX - LastRectX), (LastY - LastRectY));
+
+            if (Properties.Settings.Default.ShiftLoot)
+                SendKeyboardAction(16, keyState.KEYDOWN);
+
+            SendNotifyMessage(Wow, WM_RBUTTONDOWN, (UIntPtr)1, (IntPtr)dWord);
+            Thread.Sleep(100);
+            SendNotifyMessage(Wow, WM_RBUTTONUP, (UIntPtr)1, (IntPtr)dWord);
+
+            if (Properties.Settings.Default.ShiftLoot)
+                SendKeyboardAction(16, keyState.KEYUP);
+        }
+        public static void SendMouseClick(IntPtr Wow)
+        {
             long dWord = MakeDWord((LastX - LastRectX), (LastY - LastRectY));
 
             if (Properties.Settings.Default.ShiftLoot)

--- a/UltimateFishBot/Classes/Helpers/Win32.cs
+++ b/UltimateFishBot/Classes/Helpers/Win32.cs
@@ -77,17 +77,32 @@ namespace UltimateFishBot.Classes.Helpers
         private const uint WM_RBUTTONDOWN = 516;
         private const uint WM_RBUTTONUP = 517;
 
+
         public static Rectangle GetWowRectangle()
         {
-            IntPtr Wow = FindWindow("GxWindowClass", "World Of Warcraft");
+            IntPtr Wow = FindWowWindow();
             Rect Win32ApiRect = new Rect();
             GetWindowRect(Wow, ref Win32ApiRect);
+            System.Console.WriteLine("right rectangle:");
+            System.Console.WriteLine(Win32ApiRect.Right);
             Rectangle myRect = new Rectangle();
             myRect.X = Win32ApiRect.Left;
             myRect.Y = Win32ApiRect.Top;
             myRect.Width = (Win32ApiRect.Right - Win32ApiRect.Left);
             myRect.Height = (Win32ApiRect.Bottom - Win32ApiRect.Top);
             return myRect;
+        }
+        public static IntPtr FindWowWindow()
+        {
+            Process[] processlist = Process.GetProcesses();
+            foreach(Process process in processlist)
+            {
+                if(process.MainWindowTitle.Equals("World of Warcraft"))
+                {
+                    return process.MainWindowHandle;
+                }
+            }
+            return new IntPtr();
         }
 
         public static Bitmap GetCursorIcon(CursorInfo actualCursor, int width = 35, int height = 35)
@@ -167,7 +182,7 @@ namespace UltimateFishBot.Classes.Helpers
 
         public static void SendMouseClick()
         {
-            IntPtr Wow = FindWindow("GxWindowClass", "World Of Warcraft");
+            IntPtr Wow = FindWowWindow();
             long dWord = MakeDWord((LastX - LastRectX), (LastY - LastRectY));
 
             if (Properties.Settings.Default.ShiftLoot)

--- a/UltimateFishBot/Classes/Helpers/Win32.cs
+++ b/UltimateFishBot/Classes/Helpers/Win32.cs
@@ -40,6 +40,14 @@ namespace UltimateFishBot.Classes.Helpers
             EXTENDEDKEY = 1,
             KEYUP = 2
         };
+        private enum ShowWindowEnum
+        {
+            Hide = 0,
+            ShowNormal = 1, ShowMinimized = 2, ShowMaximized = 3,
+            Maximize = 3, ShowNormalNoActivate = 4, Show = 5,
+            Minimize = 6, ShowMinNoActivate = 7, ShowNoActivate = 8,
+            Restore = 9, ShowDefault = 10, ForceMinimized = 11
+        };
 
         [DllImport("user32.dll", EntryPoint = "FindWindow")]
         private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
@@ -70,6 +78,12 @@ namespace UltimateFishBot.Classes.Helpers
 
         [DllImport("user32.dll")]
         public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        [DllImport("user32.dll")]
+        private static extern bool IsIconic(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        static extern bool ShowWindow(IntPtr hWnd, ShowWindowEnum flags);
 
         private const uint WM_LBUTTONDOWN = 513;
         private const uint WM_LBUTTONUP = 514;
@@ -156,6 +170,11 @@ namespace UltimateFishBot.Classes.Helpers
         static public void ActivateApp(IntPtr Wow)
         {
             SetForegroundWindow(Wow);
+            //AllowSetForegroundWindow(Process.GetCurrentProcess().Id);
+            if (IsIconic(Wow))
+            {
+                ShowWindow(Wow, ShowWindowEnum.Restore);
+            }
         }
 
         public static void MoveMouse(int x, int y)

--- a/UltimateFishBot/Classes/Manager.cs
+++ b/UltimateFishBot/Classes/Manager.cs
@@ -59,12 +59,15 @@ namespace UltimateFishBot.Classes
         private const int SECOND = 1000;
         private const int MINUTE = 60 * SECOND;
 
+        private IntPtr WowWindowPointer;
+
         public Manager(IManagerEventHandler managerEventHandler, IProgress<string> progressHandle)
         {
             m_managerEventHandler    = managerEventHandler;
+            this.WowWindowPointer = Helpers.Win32.FindWowWindow();
 
-            m_eyes                   = new Eyes();
-            m_hands                  = new Hands();
+            m_eyes                   = new Eyes(this.WowWindowPointer);
+            m_hands                  = new Hands(this.WowWindowPointer);
             m_ears                   = new Ears();
             m_mouth                  = new Mouth(progressHandle);
             m_legs                   = new Legs();


### PR DESCRIPTION
Refactor of code to pass a copy of IntPtr of the World of Warcraft MainWindow handle. Various functions were calling the function to find the WoW window from a static context. These redundant searches through the process list could cause long wait times on systems with large process lists.

New code should be more responsive and performant on systems with many running processes.

May address #68 and issues raised in #8