### PR TITLE
Check if mouse cursor is already on bobber after each cast

### DIFF
--- a/UltimateFishBot/Classes/BodyParts/Eyes.cs
+++ b/UltimateFishBot/Classes/BodyParts/Eyes.cs
@@ -17,6 +17,9 @@ namespace UltimateFishBot.Classes.BodyParts
         Rectangle wowRectangle;
         private Win32.CursorInfo m_noFishCursor;
 
+        public bool CheckBobber(CancellationToken cancellationToken)
+            => ImageCompare(Win32.GetCursorIcon(Win32.GetCurrentCursor()), Properties.Resources.fishIcon35x35);
+
         public async Task<bool> LookForBobber(CancellationToken cancellationToken)
         {
             m_noFishCursor = Win32.GetNoFishCursor();

--- a/UltimateFishBot/Classes/Manager.cs
+++ b/UltimateFishBot/Classes/Manager.cs
@@ -262,12 +262,15 @@ namespace UltimateFishBot.Classes
             m_mouth.Say(Translate.GetTranslate("manager", "LABEL_CASTING"));
             await m_hands.Cast(cancellationToken);
 
-            m_mouth.Say(Translate.GetTranslate("manager", "LABEL_FINDING"));
-            bool didFindFish = await m_eyes.LookForBobber(cancellationToken);
-            if (!didFindFish)
+            if (!m_eyes.CheckBobber(cancellationToken))
             {
-                m_fishingStats.RecordBobberNotFound();
-                return;
+                m_mouth.Say(Translate.GetTranslate("manager", "LABEL_FINDING"));
+                bool didFindFish = await m_eyes.LookForBobber(cancellationToken);
+                if (!didFindFish)
+                {
+                    m_fishingStats.RecordBobberNotFound();
+                    return;
+                }
             }
 
             // Update UI with wait status            


### PR DESCRIPTION
When zoomed in, there is a pretty high chance that mouse cursor is already in the right place. This change does an image compare of current cursor and skips mouse moving steps if images are equal.