### PR TITLE
Fix a bug finding the window & listen for the fish earlier

### DIFF
--- a/UltimateFishBot/Classes/Helpers/Win32.cs
+++ b/UltimateFishBot/Classes/Helpers/Win32.cs
@@ -79,7 +79,7 @@ namespace UltimateFishBot.Classes.Helpers
 
         public static Rectangle GetWowRectangle()
         {
-            IntPtr Wow = FindWindow("GxWindowClass", "World Of Warcraft");
+            IntPtr Wow = FindWindow(null, "World Of Warcraft");
             Rect Win32ApiRect = new Rect();
             GetWindowRect(Wow, ref Win32ApiRect);
             Rectangle myRect = new Rectangle();
@@ -167,7 +167,7 @@ namespace UltimateFishBot.Classes.Helpers
 
         public static void SendMouseClick()
         {
-            IntPtr Wow = FindWindow("GxWindowClass", "World Of Warcraft");
+            IntPtr Wow = FindWindow(null, "World Of Warcraft");
             long dWord = MakeDWord((LastX - LastRectX), (LastY - LastRectY));
 
             if (Properties.Settings.Default.ShiftLoot)


### PR DESCRIPTION
* This resolves an issue with the FindWindow in SendMouseClick & GetWowRectangle.
* We also want to listen for the fish catch asynchronously before the bobber is found to allow for instant looting (assuming the fish is heard before the bobber is found).